### PR TITLE
Fix compatibility with Flutter 1.22

### DIFF
--- a/.idea/libraries/Dart_Packages.xml
+++ b/.idea/libraries/Dart_Packages.xml
@@ -5,182 +5,182 @@
         <entry key="async">
           <value>
             <list>
-              <option value="$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/async-2.4.2/lib" />
+              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/async-2.5.0-nullsafety/lib" />
             </list>
           </value>
         </entry>
         <entry key="boolean_selector">
           <value>
             <list>
-              <option value="$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/boolean_selector-2.0.0/lib" />
+              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/boolean_selector-2.1.0-nullsafety/lib" />
             </list>
           </value>
         </entry>
         <entry key="characters">
           <value>
             <list>
-              <option value="$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/characters-1.0.0/lib" />
+              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/characters-1.1.0-nullsafety.2/lib" />
             </list>
           </value>
         </entry>
         <entry key="charcode">
           <value>
             <list>
-              <option value="$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/charcode-1.1.3/lib" />
+              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/charcode-1.2.0-nullsafety/lib" />
             </list>
           </value>
         </entry>
         <entry key="clock">
           <value>
             <list>
-              <option value="$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/clock-1.0.1/lib" />
+              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/clock-1.1.0-nullsafety/lib" />
             </list>
           </value>
         </entry>
         <entry key="collection">
           <value>
             <list>
-              <option value="$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/collection-1.14.13/lib" />
+              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/collection-1.15.0-nullsafety.2/lib" />
             </list>
           </value>
         </entry>
         <entry key="cupertino_icons">
           <value>
             <list>
-              <option value="$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/cupertino_icons-0.1.3/lib" />
+              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/cupertino_icons-0.1.3/lib" />
             </list>
           </value>
         </entry>
         <entry key="fake_async">
           <value>
             <list>
-              <option value="$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/fake_async-1.1.0/lib" />
+              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/fake_async-1.1.0-nullsafety/lib" />
             </list>
           </value>
         </entry>
         <entry key="flutter">
           <value>
             <list>
-              <option value="$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/packages/flutter/lib" />
+              <option value="C:/src/flutter/packages/flutter/lib" />
             </list>
           </value>
         </entry>
         <entry key="flutter_test">
           <value>
             <list>
-              <option value="$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/packages/flutter_test/lib" />
+              <option value="C:/src/flutter/packages/flutter_test/lib" />
             </list>
           </value>
         </entry>
         <entry key="matcher">
           <value>
             <list>
-              <option value="$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/matcher-0.12.8/lib" />
+              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/matcher-0.12.10-nullsafety/lib" />
             </list>
           </value>
         </entry>
         <entry key="meta">
           <value>
             <list>
-              <option value="$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/meta-1.1.8/lib" />
+              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/meta-1.3.0-nullsafety.2/lib" />
             </list>
           </value>
         </entry>
         <entry key="path">
           <value>
             <list>
-              <option value="$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/path-1.7.0/lib" />
+              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/path-1.8.0-nullsafety/lib" />
             </list>
           </value>
         </entry>
         <entry key="sky_engine">
           <value>
             <list>
-              <option value="$flutter$/cache/pkg/sky_engine/lib" />
+              <option value="C:/src/flutter/bin/cache/pkg/sky_engine/lib" />
             </list>
           </value>
         </entry>
         <entry key="source_span">
           <value>
             <list>
-              <option value="$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/source_span-1.7.0/lib" />
+              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/source_span-1.8.0-nullsafety/lib" />
             </list>
           </value>
         </entry>
         <entry key="stack_trace">
           <value>
             <list>
-              <option value="$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/stack_trace-1.9.5/lib" />
+              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/stack_trace-1.10.0-nullsafety/lib" />
             </list>
           </value>
         </entry>
         <entry key="stream_channel">
           <value>
             <list>
-              <option value="$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/stream_channel-2.0.0/lib" />
+              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/stream_channel-2.1.0-nullsafety/lib" />
             </list>
           </value>
         </entry>
         <entry key="string_scanner">
           <value>
             <list>
-              <option value="$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/string_scanner-1.0.5/lib" />
+              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/string_scanner-1.1.0-nullsafety/lib" />
             </list>
           </value>
         </entry>
         <entry key="term_glyph">
           <value>
             <list>
-              <option value="$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/term_glyph-1.1.0/lib" />
+              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/term_glyph-1.2.0-nullsafety/lib" />
             </list>
           </value>
         </entry>
         <entry key="test_api">
           <value>
             <list>
-              <option value="$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/test_api-0.2.17/lib" />
+              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/test_api-0.2.19-nullsafety/lib" />
             </list>
           </value>
         </entry>
         <entry key="typed_data">
           <value>
             <list>
-              <option value="$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/typed_data-1.2.0/lib" />
+              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/typed_data-1.3.0-nullsafety.2/lib" />
             </list>
           </value>
         </entry>
         <entry key="vector_math">
           <value>
             <list>
-              <option value="$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/vector_math-2.0.8/lib" />
+              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/vector_math-2.1.0-nullsafety.2/lib" />
             </list>
           </value>
         </entry>
       </option>
     </properties>
     <CLASSES>
-      <root url="file://$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/async-2.4.2/lib" />
-      <root url="file://$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/boolean_selector-2.0.0/lib" />
-      <root url="file://$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/characters-1.0.0/lib" />
-      <root url="file://$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/charcode-1.1.3/lib" />
-      <root url="file://$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/clock-1.0.1/lib" />
-      <root url="file://$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/collection-1.14.13/lib" />
-      <root url="file://$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/cupertino_icons-0.1.3/lib" />
-      <root url="file://$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/fake_async-1.1.0/lib" />
-      <root url="file://$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/matcher-0.12.8/lib" />
-      <root url="file://$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/meta-1.1.8/lib" />
-      <root url="file://$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/path-1.7.0/lib" />
-      <root url="file://$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/source_span-1.7.0/lib" />
-      <root url="file://$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/stack_trace-1.9.5/lib" />
-      <root url="file://$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/stream_channel-2.0.0/lib" />
-      <root url="file://$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/string_scanner-1.0.5/lib" />
-      <root url="file://$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/term_glyph-1.1.0/lib" />
-      <root url="file://$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/test_api-0.2.17/lib" />
-      <root url="file://$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/typed_data-1.2.0/lib" />
-      <root url="file://$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/vector_math-2.0.8/lib" />
-      <root url="file://$flutter$/cache/pkg/sky_engine/lib" />
-      <root url="file://$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/packages/flutter/lib" />
-      <root url="file://$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/packages/flutter_test/lib" />
+      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/async-2.5.0-nullsafety/lib" />
+      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/boolean_selector-2.1.0-nullsafety/lib" />
+      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/characters-1.1.0-nullsafety.2/lib" />
+      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/charcode-1.2.0-nullsafety/lib" />
+      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/clock-1.1.0-nullsafety/lib" />
+      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/collection-1.15.0-nullsafety.2/lib" />
+      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/cupertino_icons-0.1.3/lib" />
+      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/fake_async-1.1.0-nullsafety/lib" />
+      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/matcher-0.12.10-nullsafety/lib" />
+      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/meta-1.3.0-nullsafety.2/lib" />
+      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/path-1.8.0-nullsafety/lib" />
+      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/source_span-1.8.0-nullsafety/lib" />
+      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/stack_trace-1.10.0-nullsafety/lib" />
+      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/stream_channel-2.1.0-nullsafety/lib" />
+      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/string_scanner-1.1.0-nullsafety/lib" />
+      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/term_glyph-1.2.0-nullsafety/lib" />
+      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/test_api-0.2.19-nullsafety/lib" />
+      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/typed_data-1.3.0-nullsafety.2/lib" />
+      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/vector_math-2.1.0-nullsafety.2/lib" />
+      <root url="file://C:/src/flutter/bin/cache/pkg/sky_engine/lib" />
+      <root url="file://C:/src/flutter/packages/flutter/lib" />
+      <root url="file://C:/src/flutter/packages/flutter_test/lib" />
     </CLASSES>
     <JAVADOC />
     <SOURCES />

--- a/.idea/libraries/Dart_Packages.xml
+++ b/.idea/libraries/Dart_Packages.xml
@@ -5,182 +5,182 @@
         <entry key="async">
           <value>
             <list>
-              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/async-2.5.0-nullsafety/lib" />
+              <option value="$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/async-2.4.2/lib" />
             </list>
           </value>
         </entry>
         <entry key="boolean_selector">
           <value>
             <list>
-              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/boolean_selector-2.1.0-nullsafety/lib" />
+              <option value="$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/boolean_selector-2.0.0/lib" />
             </list>
           </value>
         </entry>
         <entry key="characters">
           <value>
             <list>
-              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/characters-1.1.0-nullsafety.2/lib" />
+              <option value="$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/characters-1.0.0/lib" />
             </list>
           </value>
         </entry>
         <entry key="charcode">
           <value>
             <list>
-              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/charcode-1.2.0-nullsafety/lib" />
+              <option value="$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/charcode-1.1.3/lib" />
             </list>
           </value>
         </entry>
         <entry key="clock">
           <value>
             <list>
-              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/clock-1.1.0-nullsafety/lib" />
+              <option value="$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/clock-1.0.1/lib" />
             </list>
           </value>
         </entry>
         <entry key="collection">
           <value>
             <list>
-              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/collection-1.15.0-nullsafety.2/lib" />
+              <option value="$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/collection-1.14.13/lib" />
             </list>
           </value>
         </entry>
         <entry key="cupertino_icons">
           <value>
             <list>
-              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/cupertino_icons-0.1.3/lib" />
+              <option value="$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/cupertino_icons-0.1.3/lib" />
             </list>
           </value>
         </entry>
         <entry key="fake_async">
           <value>
             <list>
-              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/fake_async-1.1.0-nullsafety/lib" />
+              <option value="$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/fake_async-1.1.0/lib" />
             </list>
           </value>
         </entry>
         <entry key="flutter">
           <value>
             <list>
-              <option value="C:/src/flutter/packages/flutter/lib" />
+              <option value="$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/packages/flutter/lib" />
             </list>
           </value>
         </entry>
         <entry key="flutter_test">
           <value>
             <list>
-              <option value="C:/src/flutter/packages/flutter_test/lib" />
+              <option value="$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/packages/flutter_test/lib" />
             </list>
           </value>
         </entry>
         <entry key="matcher">
           <value>
             <list>
-              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/matcher-0.12.10-nullsafety/lib" />
+              <option value="$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/matcher-0.12.8/lib" />
             </list>
           </value>
         </entry>
         <entry key="meta">
           <value>
             <list>
-              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/meta-1.3.0-nullsafety.2/lib" />
+              <option value="$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/meta-1.1.8/lib" />
             </list>
           </value>
         </entry>
         <entry key="path">
           <value>
             <list>
-              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/path-1.8.0-nullsafety/lib" />
+              <option value="$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/path-1.7.0/lib" />
             </list>
           </value>
         </entry>
         <entry key="sky_engine">
           <value>
             <list>
-              <option value="C:/src/flutter/bin/cache/pkg/sky_engine/lib" />
+              <option value="$flutter$/cache/pkg/sky_engine/lib" />
             </list>
           </value>
         </entry>
         <entry key="source_span">
           <value>
             <list>
-              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/source_span-1.8.0-nullsafety/lib" />
+              <option value="$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/source_span-1.7.0/lib" />
             </list>
           </value>
         </entry>
         <entry key="stack_trace">
           <value>
             <list>
-              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/stack_trace-1.10.0-nullsafety/lib" />
+              <option value="$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/stack_trace-1.9.5/lib" />
             </list>
           </value>
         </entry>
         <entry key="stream_channel">
           <value>
             <list>
-              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/stream_channel-2.1.0-nullsafety/lib" />
+              <option value="$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/stream_channel-2.0.0/lib" />
             </list>
           </value>
         </entry>
         <entry key="string_scanner">
           <value>
             <list>
-              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/string_scanner-1.1.0-nullsafety/lib" />
+              <option value="$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/string_scanner-1.0.5/lib" />
             </list>
           </value>
         </entry>
         <entry key="term_glyph">
           <value>
             <list>
-              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/term_glyph-1.2.0-nullsafety/lib" />
+              <option value="$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/term_glyph-1.1.0/lib" />
             </list>
           </value>
         </entry>
         <entry key="test_api">
           <value>
             <list>
-              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/test_api-0.2.19-nullsafety/lib" />
+              <option value="$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/test_api-0.2.17/lib" />
             </list>
           </value>
         </entry>
         <entry key="typed_data">
           <value>
             <list>
-              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/typed_data-1.3.0-nullsafety.2/lib" />
+              <option value="$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/typed_data-1.2.0/lib" />
             </list>
           </value>
         </entry>
         <entry key="vector_math">
           <value>
             <list>
-              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/vector_math-2.1.0-nullsafety.2/lib" />
+              <option value="$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/vector_math-2.0.8/lib" />
             </list>
           </value>
         </entry>
       </option>
     </properties>
     <CLASSES>
-      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/async-2.5.0-nullsafety/lib" />
-      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/boolean_selector-2.1.0-nullsafety/lib" />
-      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/characters-1.1.0-nullsafety.2/lib" />
-      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/charcode-1.2.0-nullsafety/lib" />
-      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/clock-1.1.0-nullsafety/lib" />
-      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/collection-1.15.0-nullsafety.2/lib" />
-      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/cupertino_icons-0.1.3/lib" />
-      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/fake_async-1.1.0-nullsafety/lib" />
-      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/matcher-0.12.10-nullsafety/lib" />
-      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/meta-1.3.0-nullsafety.2/lib" />
-      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/path-1.8.0-nullsafety/lib" />
-      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/source_span-1.8.0-nullsafety/lib" />
-      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/stack_trace-1.10.0-nullsafety/lib" />
-      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/stream_channel-2.1.0-nullsafety/lib" />
-      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/string_scanner-1.1.0-nullsafety/lib" />
-      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/term_glyph-1.2.0-nullsafety/lib" />
-      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/test_api-0.2.19-nullsafety/lib" />
-      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/typed_data-1.3.0-nullsafety.2/lib" />
-      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/vector_math-2.1.0-nullsafety.2/lib" />
-      <root url="file://C:/src/flutter/bin/cache/pkg/sky_engine/lib" />
-      <root url="file://C:/src/flutter/packages/flutter/lib" />
-      <root url="file://C:/src/flutter/packages/flutter_test/lib" />
+      <root url="file://$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/async-2.4.2/lib" />
+      <root url="file://$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/boolean_selector-2.0.0/lib" />
+      <root url="file://$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/characters-1.0.0/lib" />
+      <root url="file://$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/charcode-1.1.3/lib" />
+      <root url="file://$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/clock-1.0.1/lib" />
+      <root url="file://$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/collection-1.14.13/lib" />
+      <root url="file://$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/cupertino_icons-0.1.3/lib" />
+      <root url="file://$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/fake_async-1.1.0/lib" />
+      <root url="file://$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/matcher-0.12.8/lib" />
+      <root url="file://$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/meta-1.1.8/lib" />
+      <root url="file://$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/path-1.7.0/lib" />
+      <root url="file://$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/source_span-1.7.0/lib" />
+      <root url="file://$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/stack_trace-1.9.5/lib" />
+      <root url="file://$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/stream_channel-2.0.0/lib" />
+      <root url="file://$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/string_scanner-1.0.5/lib" />
+      <root url="file://$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/term_glyph-1.1.0/lib" />
+      <root url="file://$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/test_api-0.2.17/lib" />
+      <root url="file://$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/typed_data-1.2.0/lib" />
+      <root url="file://$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/.pub-cache/hosted/pub.dartlang.org/vector_math-2.0.8/lib" />
+      <root url="file://$flutter$/cache/pkg/sky_engine/lib" />
+      <root url="file://$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/packages/flutter/lib" />
+      <root url="file://$USER_HOME$/OfficeFiles/Mobile/SDK/flutter/packages/flutter_test/lib" />
     </CLASSES>
     <JAVADOC />
     <SOURCES />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.2.0]
+
+- Removed `overflow` to be compatible with FLutter 1.22
+
 ## [1.1.2+3]
 
 - Key added to TabItem

--- a/lib/cuberto_bottom_bar.dart
+++ b/lib/cuberto_bottom_bar.dart
@@ -4,7 +4,7 @@ import 'package:cuberto_bottom_bar/internal/tab_item.dart';
 
 import 'package:flutter/material.dart';
 
-const int ANIM_DURATION = 300;
+const int kAnimationDuration = 300;
 
 class CubertoBottomBar extends StatefulWidget {
   /// The callback that will be executed each time the tab is changed
@@ -69,8 +69,7 @@ class CubertoBottomBar extends StatefulWidget {
   CubertoBottomBarState createState() => CubertoBottomBarState();
 }
 
-class CubertoBottomBarState extends State<CubertoBottomBar>
-    with TickerProviderStateMixin, RouteAware {
+class CubertoBottomBarState extends State<CubertoBottomBar> {
   IconData nextIcon = Icons.search;
   IconData activeIcon = Icons.search;
   int currentSelected = 0;
@@ -175,36 +174,30 @@ class CubertoBottomBarState extends State<CubertoBottomBar>
     else {
       actions = Container();
     }
-    return Stack(
-      overflow: Overflow.clip,
-      alignment: Alignment.bottomCenter,
-      children: <Widget>[
-        Container(
-          padding: widget.padding ??
-              EdgeInsets.symmetric(
-                horizontal: 12.0,
-                vertical: 8.0,
+    return Container(
+      padding: widget.padding ??
+          EdgeInsets.symmetric(
+            horizontal: 12.0,
+            vertical: 8.0,
+          ),
+      decoration: BoxDecoration(
+        color: barBackgroundColor,
+        borderRadius: widget.barBorderRadius,
+        boxShadow: widget.barShadow ??
+            <BoxShadow>[
+              BoxShadow(
+                color: Colors.black12,
+                offset: Offset(0, -1),
+                blurRadius: 8,
               ),
-          decoration: BoxDecoration(
-            color: barBackgroundColor,
-            borderRadius: widget.barBorderRadius,
-            boxShadow: widget.barShadow ??
-                [
-                  BoxShadow(
-                    color: Colors.black12,
-                    offset: Offset(0, -1),
-                    blurRadius: 8,
-                  ),
-                ],
-          ),
-          child: setUpTabs(
-            drawerStyle,
-            widget.tabs,
-            widget.onTabChangedListener,
-            actions,
-          ),
-        ),
-      ],
+            ],
+      ),
+      child: setUpTabs(
+        drawerStyle,
+        widget.tabs,
+        widget.onTabChangedListener,
+        actions,
+      ),
     );
   }
 
@@ -275,12 +268,12 @@ class CubertoBottomBarState extends State<CubertoBottomBar>
   }
 
   _initAnimationAndStart(double from, double to) {
-    Future.delayed(Duration(milliseconds: ANIM_DURATION ~/ 5), () {
+    Future.delayed(Duration(milliseconds: kAnimationDuration ~/ 5), () {
       setState(() {
         activeIcon = nextIcon;
       });
     }).then((_) {
-      Future.delayed(Duration(milliseconds: (ANIM_DURATION ~/ 5 * 3)), () {
+      Future.delayed(Duration(milliseconds: (kAnimationDuration ~/ 5 * 3)), () {
         setState(() {});
       });
     });

--- a/lib/internal/tab_item.dart
+++ b/lib/internal/tab_item.dart
@@ -104,13 +104,13 @@ class _TabItemState extends State<TabItem> {
     return InkWell(
       child: AnimatedContainer(
         padding: EdgeInsets.fromLTRB(15.0, 7.0, 15.0, 7.0),
-        duration: Duration(milliseconds: ANIM_DURATION),
+        duration: Duration(milliseconds: kAnimationDuration),
         decoration: BoxDecoration(
             gradient: backGradient,
             borderRadius:
                 widget.borderRadius ?? BorderRadius.all(Radius.circular(20.0))),
         child: AnimatedContainer(
-          duration: Duration(milliseconds: ANIM_DURATION),
+          duration: Duration(milliseconds: kAnimationDuration),
           child: Row(
             crossAxisAlignment: CrossAxisAlignment.center,
             children: <Widget>[
@@ -120,7 +120,7 @@ class _TabItemState extends State<TabItem> {
               ),
               SizedBox(width: 8.0),
               AnimatedContainer(
-                duration: Duration(milliseconds: ANIM_DURATION),
+                duration: Duration(milliseconds: kAnimationDuration),
                 padding: widget.selected
                     ? EdgeInsets.only(left: 3.0, right: 3.0)
                     : EdgeInsets.all(0.0),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cuberto_bottom_bar
 description: An animated bottom navigation bar supporting drawer icon at start or end or can be used with the drawer icon and is provided with 2 different styles.
-version: 1.1.2+3
+version: 1.2.0
 homepage: https://github.com/kushalmahapatro/cuberto_bottom_bar
 
 environment:

--- a/test/cuberto_bottom_bar_test.dart
+++ b/test/cuberto_bottom_bar_test.dart
@@ -3,101 +3,71 @@ import 'package:flutter/material.dart';
 import 'package:cuberto_bottom_bar/cuberto_bottom_bar.dart';
 
 void main() {
-  Widget makeTestableWidget({@required Widget child}) {
+  Widget makeTestableWidget({Widget child}) {
     return MaterialApp(
-      theme: ThemeData(primaryColor: Colors.pink, brightness: Brightness.light),
-      home: Scaffold(
-        body: Placeholder(),
-        bottomNavigationBar: child,
-      ),
-    );
+        theme: ThemeData(primaryColor: Colors.pink,
+            brightness: Brightness.light),
+        home: Scaffold(
+            body: Center(),
+            bottomNavigationBar: child));
   }
 
-  testWidgets('Correct styling for tabs', (WidgetTester tester) async {
+  testWidgets('Fancy Nav has correct tabs', (WidgetTester tester) async {
     CubertoBottomBar fn = CubertoBottomBar(
-      tabs: <TabData>[
-        TabData(iconData: Icons.home, title: 'Home'),
-        TabData(iconData: Icons.search, title: 'Search'),
+      tabs: [
+        TabData(iconData: Icons.home, title: "Home"),
+        TabData(iconData: Icons.search, title: "Search")
       ],
-      onTabChangedListener: (_, __, ___) {},
-      tabStyle: CubertoTabStyle.STYLE_FADED_BACKGROUND,
+      onTabChangedListener: (position, title, color) {},
     );
 
     await tester.pumpWidget(makeTestableWidget(child: fn));
 
-    final homeFinder = find.text('Home');
-    final homeIconFinder = find.byIcon(Icons.home);
-    final searchFinder = find.text('Search');
-    final searchIconFinder = find.byIcon(Icons.search);
-
+    final homeFinder = find.text("Home");
     expect(homeFinder, findsOneWidget);
-    expect(homeIconFinder, findsOneWidget);
-    expect(searchFinder, findsNothing);
+
+    final homeIconFinder = find.byIcon(Icons.home);
+    expect(homeIconFinder, findsNWidgets(2));
+
+    final searchIconFinder = find.byIcon(Icons.search);
     expect(searchIconFinder, findsOneWidget);
+
+    final searchFinder = find.text("Search");
+    expect(searchFinder, findsOneWidget);
+
+    final randomFinder = find.text("Hello");
+    expect(randomFinder, findsNothing);
+
   });
 
-  testWidgets('Clicking icon moves selected icon', (WidgetTester tester) async {
-    await tester.pumpWidget(_TestApp());
+  testWidgets('Clicking icon moves the circle', (WidgetTester tester) async {
+    CubertoBottomBar fn = CubertoBottomBar(
+      tabs: [
+        TabData(iconData: Icons.home, title: "Home"),
+        TabData(iconData: Icons.search, title: "Search")
+      ],
+      onTabChangedListener: (position, title, color) {},
+    );
 
-    final homeFinder = find.text('Home');
+    await tester.pumpWidget(makeTestableWidget(child: fn));
+
+    final homeFinder = find.text("Home");
     final homeIconFinder = find.byIcon(Icons.home);
-    final searchFinder = find.text('Search');
     final searchIconFinder = find.byIcon(Icons.search);
+    final searchFinder = find.text("Search");
+    final randomFinder = find.text("Hello");
 
     expect(homeFinder, findsOneWidget);
-    expect(homeIconFinder, findsOneWidget);
-    expect(searchFinder, findsNothing);
+    expect(homeIconFinder, findsNWidgets(2));
     expect(searchIconFinder, findsOneWidget);
+    expect(searchFinder, findsOneWidget);
+    expect(randomFinder, findsNothing);
 
     await tester.tap(searchIconFinder);
-    await tester.pump(const Duration(milliseconds: kAnimationDuration));
+    await tester.pumpAndSettle();
 
-    expect(homeFinder, findsNothing);
+    expect(searchIconFinder, findsNWidgets(2));
     expect(homeIconFinder, findsOneWidget);
-    expect(searchFinder, findsOneWidget);
-    expect(searchIconFinder, findsOneWidget);
 
-    await tester.tap(homeIconFinder);
-    await tester.pump(const Duration(milliseconds: kAnimationDuration));
-
-    expect(homeFinder, findsOneWidget);
-    expect(homeIconFinder, findsOneWidget);
-    expect(searchFinder, findsNothing);
-    expect(searchIconFinder, findsOneWidget);
   });
-}
-
-class _TestApp extends StatefulWidget {
-  @override
-  __TestAppState createState() => __TestAppState();
-}
-
-class __TestAppState extends State<_TestApp> {
-  int _selected;
-  @override
-  void initState() {
-    super.initState();
-    _selected = 0;
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      home: Scaffold(
-        body: Placeholder(),
-        bottomNavigationBar: CubertoBottomBar(
-          onTabChangedListener: (int position, _, __) {
-            setState(() {
-              _selected = position;
-            });
-          },
-          selectedTab: _selected,
-          tabs: <TabData>[
-            TabData(iconData: Icons.home, title: 'Home'),
-            TabData(iconData: Icons.search, title: 'Search')
-          ],
-        ),
-      ),
-    );
-  }
 }

--- a/test/cuberto_bottom_bar_test.dart
+++ b/test/cuberto_bottom_bar_test.dart
@@ -3,71 +3,101 @@ import 'package:flutter/material.dart';
 import 'package:cuberto_bottom_bar/cuberto_bottom_bar.dart';
 
 void main() {
-  Widget makeTestableWidget({Widget child}) {
+  Widget makeTestableWidget({@required Widget child}) {
     return MaterialApp(
-        theme: ThemeData(primaryColor: Colors.pink,
-            brightness: Brightness.light),
-        home: Scaffold(
-            body: Center(),
-            bottomNavigationBar: child));
+      theme: ThemeData(primaryColor: Colors.pink, brightness: Brightness.light),
+      home: Scaffold(
+        body: Placeholder(),
+        bottomNavigationBar: child,
+      ),
+    );
   }
 
-  testWidgets('Fancy Nav has correct tabs', (WidgetTester tester) async {
+  testWidgets('Correct styling for tabs', (WidgetTester tester) async {
     CubertoBottomBar fn = CubertoBottomBar(
-      tabs: [
-        TabData(iconData: Icons.home, title: "Home"),
-        TabData(iconData: Icons.search, title: "Search")
+      tabs: <TabData>[
+        TabData(iconData: Icons.home, title: 'Home'),
+        TabData(iconData: Icons.search, title: 'Search'),
       ],
-      onTabChangedListener: (position, title, color) {},
+      onTabChangedListener: (_, __, ___) {},
+      tabStyle: CubertoTabStyle.STYLE_FADED_BACKGROUND,
     );
 
     await tester.pumpWidget(makeTestableWidget(child: fn));
 
-    final homeFinder = find.text("Home");
-    expect(homeFinder, findsOneWidget);
-
+    final homeFinder = find.text('Home');
     final homeIconFinder = find.byIcon(Icons.home);
-    expect(homeIconFinder, findsNWidgets(2));
-
+    final searchFinder = find.text('Search');
     final searchIconFinder = find.byIcon(Icons.search);
+
+    expect(homeFinder, findsOneWidget);
+    expect(homeIconFinder, findsOneWidget);
+    expect(searchFinder, findsNothing);
     expect(searchIconFinder, findsOneWidget);
-
-    final searchFinder = find.text("Search");
-    expect(searchFinder, findsOneWidget);
-
-    final randomFinder = find.text("Hello");
-    expect(randomFinder, findsNothing);
-
   });
 
-  testWidgets('Clicking icon moves the circle', (WidgetTester tester) async {
-    CubertoBottomBar fn = CubertoBottomBar(
-      tabs: [
-        TabData(iconData: Icons.home, title: "Home"),
-        TabData(iconData: Icons.search, title: "Search")
-      ],
-      onTabChangedListener: (position, title, color) {},
-    );
+  testWidgets('Clicking icon moves selected icon', (WidgetTester tester) async {
+    await tester.pumpWidget(_TestApp());
 
-    await tester.pumpWidget(makeTestableWidget(child: fn));
-
-    final homeFinder = find.text("Home");
+    final homeFinder = find.text('Home');
     final homeIconFinder = find.byIcon(Icons.home);
+    final searchFinder = find.text('Search');
     final searchIconFinder = find.byIcon(Icons.search);
-    final searchFinder = find.text("Search");
-    final randomFinder = find.text("Hello");
 
     expect(homeFinder, findsOneWidget);
-    expect(homeIconFinder, findsNWidgets(2));
+    expect(homeIconFinder, findsOneWidget);
+    expect(searchFinder, findsNothing);
     expect(searchIconFinder, findsOneWidget);
-    expect(searchFinder, findsOneWidget);
-    expect(randomFinder, findsNothing);
 
     await tester.tap(searchIconFinder);
-    await tester.pumpAndSettle();
+    await tester.pump(const Duration(milliseconds: kAnimationDuration));
 
-    expect(searchIconFinder, findsNWidgets(2));
+    expect(homeFinder, findsNothing);
     expect(homeIconFinder, findsOneWidget);
+    expect(searchFinder, findsOneWidget);
+    expect(searchIconFinder, findsOneWidget);
 
+    await tester.tap(homeIconFinder);
+    await tester.pump(const Duration(milliseconds: kAnimationDuration));
+
+    expect(homeFinder, findsOneWidget);
+    expect(homeIconFinder, findsOneWidget);
+    expect(searchFinder, findsNothing);
+    expect(searchIconFinder, findsOneWidget);
   });
+}
+
+class _TestApp extends StatefulWidget {
+  @override
+  __TestAppState createState() => __TestAppState();
+}
+
+class __TestAppState extends State<_TestApp> {
+  int _selected;
+  @override
+  void initState() {
+    super.initState();
+    _selected = 0;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Placeholder(),
+        bottomNavigationBar: CubertoBottomBar(
+          onTabChangedListener: (int position, _, __) {
+            setState(() {
+              _selected = position;
+            });
+          },
+          selectedTab: _selected,
+          tabs: <TabData>[
+            TabData(iconData: Icons.home, title: 'Home'),
+            TabData(iconData: Icons.search, title: 'Search')
+          ],
+        ),
+      ),
+    );
+  }
 }


### PR DESCRIPTION
I removed a `Stack` widget that only had one child, and a `overflow` property that has been removed in latest Flutter version. Also, fixed the tests that were failing and removed `TickerProviderStateMixin` and `RouteAware` mixins that don't seem to be in use anymore.